### PR TITLE
:dependabot: Group `boto`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      boto:
+        patterns:
+          - "boto*"


### PR DESCRIPTION
This pull request:

- Groups `boto` packages in Dependabot, `boto3` gets upset if it doesn't match `botocore`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 