### PR TITLE
:bug: Fix missing `context` from handler.py

### DIFF
--- a/src/var/task/handler.py
+++ b/src/var/task/handler.py
@@ -7,7 +7,7 @@ s3_client = boto3.client("s3")
 sm_client = boto3.client("secretsmanager")
 
 
-def handler(event, context):
+def handler(event, context): # pylint: disable=unused-argument
     object_key = event["Records"][0]["s3"]["object"]["key"]
     supplier, file_name = object_key.split("/")[:2]
     print(f"Supplier: {supplier}")

--- a/src/var/task/handler.py
+++ b/src/var/task/handler.py
@@ -7,7 +7,7 @@ s3_client = boto3.client("s3")
 sm_client = boto3.client("secretsmanager")
 
 
-def handler(event, context): # pylint: disable=unused-argument
+def handler(event, context):  # pylint: disable=unused-argument
     object_key = event["Records"][0]["s3"]["object"]["key"]
     supplier, file_name = object_key.split("/")[:2]
     print(f"Supplier: {supplier}")

--- a/src/var/task/handler.py
+++ b/src/var/task/handler.py
@@ -7,7 +7,7 @@ s3_client = boto3.client("s3")
 sm_client = boto3.client("secretsmanager")
 
 
-def handler(event):
+def handler(event, context):
     object_key = event["Records"][0]["s3"]["object"]["key"]
     supplier, file_name = object_key.split("/")[:2]
     print(f"Supplier: {supplier}")


### PR DESCRIPTION
This was removed as recommended by linting. It's not used explicitly in the code but without it when the lambda runs you get the following error: 

```
LAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html
[ERROR] TypeError: handler() takes 1 positional argument but 2 were given
Traceback (most recent call last):
  File "/var/lang/lib/python3.12/site-packages/awslambdaric/bootstrap.py", line 188, in handle_event_request
    response = request_handler(event, lambda_context)
```