### PR TITLE
🧑‍🦲 Add `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 debug: build
 	docker run -it --rm \
 		--platform linux/amd64 \
-		--hostname ingestion-scan \
+		--hostname ingestion-transfer \
 		--name analytical-platform-ingestion-transfer \
 		--entrypoint /bin/bash \
 		$(IMAGE_NAME):$(IMAGE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build debug run
+.PHONY: build debug
 
 IMAGE_NAME ?= analytical-platform.service.justice.gov.uk/ingestion-transfer
 IMAGE_TAG  ?= local

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: build debug run
+
+IMAGE_NAME ?= analytical-platform.service.justice.gov.uk/ingestion-transfer
+IMAGE_TAG  ?= local
+
+build:
+	docker build --platform linux/amd64 --file Dockerfile --tag $(IMAGE_NAME):$(IMAGE_TAG) .
+
+debug: build
+	docker run -it --rm \
+		--platform linux/amd64 \
+		--hostname ingestion-scan \
+		--name analytical-platform-ingestion-transfer \
+		--entrypoint /bin/bash \
+		$(IMAGE_NAME):$(IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -15,19 +15,13 @@ The image:
 
 ### Build
 
-```bash
-docker build --platform linux/amd64 --file Dockerfile --tag analytical-platform.service.justice.gov.uk/ingestion-transfer:local .
-```
+`make build`
 
-### Run
+### Debug
 
-```bash
-docker run -it --rm \
-  --platform linux/amd64 \
-  --hostname ingestion-transfer \
-  --name analytical-platform-ingestion-transfer \
-  analytical-platform.service.justice.gov.uk/ingestion-transfer:local
-```
+Launch a Bash terminal in the container:
+
+`make debug`
 
 ## Versions
 


### PR DESCRIPTION
Adds a Makefile which has:
- `make build` to build the image
- `make debug` builds the image and launches a terminal, opted for the name 'debug' over 'run' as we can't run the lambda container per say.